### PR TITLE
Add logger utility and integrate in API routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,4 @@ AUTH_RESEND_KEY=xxxxxxxxxxxx
 AUTH_GOOGLE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
 AUTH_GOOGLE_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 AUTH_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxx
+LOG_ENDPOINT=https://logs.example.com

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ openPanelClientId: String    // Open Panel integration client ID
 emailProvider: String        // Email service provider (currently "nodemailer")
 ```
 
+### Logging
+
+Set `LOG_ENDPOINT` in your environment to enable sending logs to a third‑party service (e.g. Logtail or Sentry). Logs are printed to the console during development and forwarded to this endpoint in production.
+
 ## Support
 
 For any questions or issues, please open an issue in the repository.

--- a/app/api/(payment)/checkout/route.ts
+++ b/app/api/(payment)/checkout/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { stripe } from '@/utils/stripe';
 import { getSupabaseClient } from '@/utils/supabase/server';
 import { auth } from '@/lib/auth';
+import { logger } from '@/utils/logger';
 export async function POST(request: Request) {
 	try {
 		const userSession = await auth()
@@ -44,8 +45,8 @@ export async function POST(request: Request) {
 
 
 		return NextResponse.json({ id: session.id, client_secret: session.client_secret });
-	} catch (error: any) {
-		console.error(error);
-		return NextResponse.json({ message: error.message }, { status: 500 });
-	}
+        } catch (error: any) {
+                logger.error('Checkout API error', error);
+                return NextResponse.json({ message: error.message }, { status: 500 });
+        }
 }

--- a/app/api/(payment)/refund/route.ts
+++ b/app/api/(payment)/refund/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { stripe } from '@/utils/stripe';
 import { auth } from '@/lib/auth';
+import { logger } from '@/utils/logger';
 
 export async function POST(request: Request) {
 	try {
@@ -24,10 +25,10 @@ export async function POST(request: Request) {
 			return new Response('Payment Intent ID is required', { status: 400 });
 		}
 
-	} catch (error: any) {
-		console.error(error);
-		return NextResponse.json({ message: error.message }, { status: 500 });
-	}
+        } catch (error: any) {
+                logger.error('Refund API error', error);
+                return NextResponse.json({ message: error.message }, { status: 500 });
+        }
 }
 
 async function getPaymentIntentId(subscriptionId: string) {
@@ -42,8 +43,8 @@ async function getPaymentIntentId(subscriptionId: string) {
 		const paymentIntentId = latestInvoice.payment_intent;
 
 		return paymentIntentId;
-	} catch (error) {
-		console.error('Get PaymentIntent ID error:', error);
-		throw new Error('Cannot get PaymentIntent ID');
-	}
+        } catch (error) {
+                logger.error('Get PaymentIntent ID error', error);
+                throw new Error('Cannot get PaymentIntent ID');
+        }
 }

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -3,6 +3,7 @@ import { getSupabaseClient } from '@/utils/supabase/server';
 import { auth } from "@/lib/auth";
 import { stripe } from '@/utils/stripe';
 import config from '@/config';
+import { logger } from '@/utils/logger';
 
 // Helper function to get plan name from price ID
 function getPlanNameFromPriceId(priceId: string): { name: string; interval: string } {
@@ -34,10 +35,10 @@ export async function GET() {
 			.eq('id', userId)
 			.single();
 
-		if (userError) {
-			console.error('Error fetching user data:', userError);
-			return NextResponse.json({ error: 'Error fetching user data' }, { status: 500 });
-		}
+                if (userError) {
+                        logger.error('Error fetching user data', userError);
+                        return NextResponse.json({ error: 'Error fetching user data' }, { status: 500 });
+                }
 
 		// Get subscription data
 		const { data: subscriptionData, error: subscriptionError } = await supabase
@@ -72,8 +73,8 @@ export async function GET() {
 			planInterval,
 			priceData
 		});
-	} catch (error) {
-		console.error('Error in profile API route:', error);
-		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-	}
-} 
+        } catch (error) {
+                logger.error('Error in profile API route', error);
+                return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+        }
+}

--- a/app/api/webhook/stripe/route.ts
+++ b/app/api/webhook/stripe/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { stripe } from '@/utils/stripe';
 import { createSupabaseAdminClient } from '@/utils/supabase/server';
 import Stripe from 'stripe';
+import { logger } from '@/utils/logger';
 // This is where we receive Stripe webhook events
 // It used to update the user data, send emails, etc...
 // By default, it'll store the user in the database
@@ -16,10 +17,10 @@ export async function POST(request: NextRequest) {
 		let event;
 		try {
 			event = await stripe.webhooks.constructEventAsync(rawBody, signature!, process.env.STRIPE_WEBHOOK_SECRET!);
-		} catch (error: any) {
-			console.error(`Webhook signature verification failed: ${error.message}`);
-			return NextResponse.json({ statusCode: 400, message: 'Webhook Error' }, { status: 400 });
-		}
+                } catch (error: any) {
+                        logger.error(`Webhook signature verification failed: ${error.message}`);
+                        return NextResponse.json({ statusCode: 400, message: 'Webhook Error' }, { status: 400 });
+                }
 
 		const eventType = event.type;
 		try {
@@ -138,10 +139,10 @@ export async function POST(request: NextRequest) {
 					break;
 				}
 			}
-		} catch (error: any) {
-			console.error('Error processing webhook:', error);
-			return NextResponse.json({ message: error.message }, { status: 500 });
-		}
+                } catch (error: any) {
+                        logger.error('Error processing webhook', error);
+                        return NextResponse.json({ message: error.message }, { status: 500 });
+                }
 
 		return NextResponse.json({ statusCode: 200, message: 'success' });
 	} catch (error: any) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import authConfig from "@/lib/auth.config"
 import NextAuth from "next-auth"
 import { NextResponse } from "next/server"
+import { withRequestLogging } from "@/utils/logger"
 
 export const config = {
 	matcher: ["/app"],
@@ -8,8 +9,10 @@ export const config = {
 
 const { auth } = NextAuth(authConfig)
 
-export default auth((req) => {
-	if (!req.auth) {
-		return NextResponse.redirect(new URL("/api/auth/signin", req.url));
-	}
+const middleware = auth((req) => {
+        if (!req.auth) {
+                return NextResponse.redirect(new URL("/api/auth/signin", req.url));
+        }
 });
+
+export default withRequestLogging(middleware);

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+interface LogPayload {
+  level: 'info' | 'warn' | 'error' | 'debug';
+  message: string;
+  meta?: any;
+}
+
+const LOG_ENDPOINT = process.env.LOG_ENDPOINT || process.env.SENTRY_WEBHOOK_URL;
+
+async function sendToEndpoint(payload: LogPayload) {
+  if (!LOG_ENDPOINT) return;
+  try {
+    await fetch(LOG_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    // Avoid recursive logging failures
+    console.error('Failed to send log', err);
+  }
+}
+
+function log(level: LogPayload['level'], message: string, meta?: any) {
+  if (process.env.NODE_ENV !== 'production') {
+    // In dev just log to console
+    console[level](message, meta ?? '');
+  } else {
+    sendToEndpoint({ level, message, meta }).catch(() => {});
+  }
+}
+
+export const logger = {
+  info: (msg: string, meta?: any) => log('info', msg, meta),
+  warn: (msg: string, meta?: any) => log('warn', msg, meta),
+  error: (msg: string, meta?: any) => log('error', msg, meta),
+  debug: (msg: string, meta?: any) => log('debug', msg, meta),
+};
+
+export function withRequestLogging(
+  handler: (req: NextRequest) => Promise<NextResponse> | NextResponse,
+) {
+  return async function (req: NextRequest): Promise<NextResponse> {
+    logger.info(`Incoming ${req.method} ${req.nextUrl.pathname}`);
+    const res = await handler(req);
+    logger.info(`Response ${res.status} ${req.nextUrl.pathname}`);
+    return res;
+  };
+}
+


### PR DESCRIPTION
## Summary
- create a basic logger utility that forwards logs to an endpoint in production
- integrate request logging middleware
- replace `console.error` statements in API routes with `logger.error`
- expose `LOG_ENDPOINT` env variable and document logging setup

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run lint:ts` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f190b1984832399ad3b5f503d1233